### PR TITLE
Apply latest node:package specifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
+# Credit
+
+All credit belongs to the original [streamconv](https://github.com/CesiumLabs/streamconv). We are just applying some latest Deno Node specifiers.
+
 # StreamConv
+
 Node.js stream to Web stream and vice versa.
 
 # Example
+
 ## Web streams to node stream
 
 ```js

--- a/mod.ts
+++ b/mod.ts
@@ -2,8 +2,8 @@ import { convert as WebToReadable } from "./src/Conv.ts";
 import { toWebStream as ReadableToWeb } from "./src/toWeb.ts";
 
 export const Converter = {
-    WebToReadable,
-    ReadableToWeb
-}
+	WebToReadable,
+	ReadableToWeb,
+};
 
 export default Converter;

--- a/src/Conv.ts
+++ b/src/Conv.ts
@@ -2,54 +2,53 @@
 based on https://github.com/Borewit/readable-web-to-node-stream
 */
 
-import { Readable } from "https://deno.land/std/node/stream.ts";
+import { Readable } from "node:stream";
 
 class StreamConv extends Readable {
+	public bytesRead: number = 0;
+	public released = false;
+	private reader: ReadableStreamReader;
+	private pendingRead!: Promise<any>;
 
-    public bytesRead: number = 0;
-    public released = false;
-    private reader: ReadableStreamReader;
-    private pendingRead!: Promise<any>;
+	constructor(stream: ReadableStream) {
+		super();
+		this.reader = stream.getReader();
+	}
 
-    constructor(stream: ReadableStream) {
-        super();
-        this.reader = stream.getReader();
-    }
+	public async _read() {
+		if (this.released) {
+			this.push(null);
+			return;
+		}
+		this.pendingRead = this.reader.read();
+		const data = await this.pendingRead;
+		// @ts-ignore
+		delete this.pendingRead;
+		if (data.done || this.released) {
+			this.push(null);
+		} else {
+			this.bytesRead += data.value.length;
+			this.push(data.value);
+		}
+	}
 
-    public async _read() {
-        if (this.released) {
-            this.push(null);
-            return;
-        }
-        this.pendingRead = this.reader.read();
-        const data = await this.pendingRead;
-        // @ts-ignore
-        delete this.pendingRead;
-        if (data.done || this.released) {
-            this.push(null);
-        } else {
-            this.bytesRead += data.value.length;
-            this.push(data.value);
-        }
-    }
+	public async waitForReadToComplete() {
+		if (this.pendingRead) {
+			await this.pendingRead;
+		}
+	}
 
-    public async waitForReadToComplete() {
-        if (this.pendingRead) {
-            await this.pendingRead;
-        }
-    }
+	public async close(): Promise<void> {
+		await this.syncAndRelease();
+	}
 
-    public async close(): Promise<void> {
-        await this.syncAndRelease();
-    }
-
-    private async syncAndRelease() {
-        this.released = true;
-        await this.waitForReadToComplete();
-        await this.reader.releaseLock();
-    }
+	private async syncAndRelease() {
+		this.released = true;
+		await this.waitForReadToComplete();
+		await this.reader.releaseLock();
+	}
 }
 
 export function convert(stream: ReadableStream) {
-    return new StreamConv(stream);
+	return new StreamConv(stream);
 }

--- a/src/toWeb.ts
+++ b/src/toWeb.ts
@@ -2,60 +2,60 @@
 based on https://github.com/xuset/readable-stream-node-to-web
 */
 
-import { Readable as NodeLikeReadable } from "https://deno.land/std/node/stream.ts";
+import { Readable as NodeLikeReadable } from "node:stream";
 
 interface ListenerInterface {
-    data: (chunk: any) => void;
-    end: (chunk: any) => void;
-    close: (err: any) => void;
-    error: (err: any) => void;
+	data: (chunk: any) => void;
+	end: (chunk: any) => void;
+	close: (err: any) => void;
+	error: (err: any) => void;
 }
 
 export function toWebStream(nodeStream: NodeLikeReadable) {
-    let destroyed = false;
-    const listeners = {} as ListenerInterface;
+	let destroyed = false;
+	const listeners = {} as ListenerInterface;
 
-    function start(controller: any) {
-        listeners['data'] = onData;
-        listeners['end'] = onData;
-        listeners['end'] = onDestroy;
-        listeners['close'] = onDestroy;
-        listeners['error'] = onDestroy;
-        for (const name in listeners) nodeStream.on(name, listeners[name as keyof ListenerInterface])
+	function start(controller: any) {
+		listeners["data"] = onData;
+		listeners["end"] = onData;
+		listeners["end"] = onDestroy;
+		listeners["close"] = onDestroy;
+		listeners["error"] = onDestroy;
+		for (const name in listeners) nodeStream.on(name, listeners[name as keyof ListenerInterface]);
 
-        nodeStream.pause()
+		nodeStream.pause();
 
-        function onData(chunk: any) {
-            if (destroyed) return
-            controller.enqueue(new Uint8Array(chunk))
-            nodeStream.pause()
-        }
+		function onData(chunk: any) {
+			if (destroyed) return;
+			controller.enqueue(new Uint8Array(chunk));
+			nodeStream.pause();
+		}
 
-        function onDestroy(err: any) {
-            if (destroyed) return
-            destroyed = true
+		function onDestroy(err: any) {
+			if (destroyed) return;
+			destroyed = true;
 
-            for (let name in listeners) nodeStream.removeListener(name, listeners[name as keyof ListenerInterface])
+			for (let name in listeners) nodeStream.removeListener(name, listeners[name as keyof ListenerInterface]);
 
-            if (err) controller.error(err)
-            else controller.close()
-        }
-    }
+			if (err) controller.error(err);
+			else controller.close();
+		}
+	}
 
-    function pull() {
-        if (destroyed) return
-        nodeStream.resume()
-    }
+	function pull() {
+		if (destroyed) return;
+		nodeStream.resume();
+	}
 
-    function cancel() {
-        destroyed = true
+	function cancel() {
+		destroyed = true;
 
-        for (const name in listeners) nodeStream.removeListener(name, listeners[name as keyof ListenerInterface])
+		for (const name in listeners) nodeStream.removeListener(name, listeners[name as keyof ListenerInterface]);
 
-        nodeStream.push(null)
-        nodeStream.pause()
-        if (nodeStream.destroy) nodeStream.destroy()
-    }
+		nodeStream.push(null);
+		nodeStream.pause();
+		if (nodeStream.destroy) nodeStream.destroy();
+	}
 
-    return new ReadableStream({ start: start, pull: pull, cancel: cancel })
+	return new ReadableStream({ start: start, pull: pull, cancel: cancel });
 }


### PR DESCRIPTION
Since Deno has removed the std/node module, and use a "node:package" specifier instead, the current v1.0.2 streamconv is not running properly under Deno 1.36+. So I fix it by using the latest node specifier.